### PR TITLE
Use postgis to determine nearest locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vscode
+target

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,18 @@
 	</developers>
 	<properties>
 		<java.version>17</java.version>
+		<!-- This version of Spring boot comes with 1.18.36, which doesn't get along with VSCode -->
+		<lombok.version>1.18.38</lombok.version>
 	</properties>
 	<dependencies>
 	<dependency>
 		<groupId>org.postgresql</groupId>
 		<artifactId>postgresql</artifactId>
+	</dependency>
+		<dependency>
+		<groupId>net.postgis</groupId>
+		<artifactId>postgis-jdbc</artifactId>
+		<version>2025.1.1</version>
 	</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/canvassing/exception/BadLocationException.java
+++ b/src/main/java/com/example/canvassing/exception/BadLocationException.java
@@ -1,0 +1,12 @@
+package com.example.canvassing.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value=HttpStatus.BAD_REQUEST, reason="This address has an invalid location")
+public class BadLocationException extends RuntimeException {
+    public BadLocationException(String message, Exception cause) {
+        super("This location is not a valid latitude/longitude", cause);
+    }
+
+}

--- a/src/main/java/com/example/canvassing/persistence/HouseholdMapper.java
+++ b/src/main/java/com/example/canvassing/persistence/HouseholdMapper.java
@@ -3,22 +3,20 @@ package com.example.canvassing.persistence;
 import com.example.canvassing.model.Household;
 import com.example.canvassing.model.Location;
 import com.example.canvassing.model.Status;
+
+import net.postgis.jdbc.PGgeometry;
+import net.postgis.jdbc.geometry.Point;
+
 import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class HouseholdMapper implements RowMapper<Household> {
-    private static final Map<Integer, Status> STATUSES = new HashMap<>();
-    static {
-        for (Status status : Status.values()) {
-            STATUSES.put(status.ordinal(), status);
-        }
-    }
     public Household mapRow(ResultSet rs, int rowNum) throws SQLException {
-        Location location = new Location(rs.getDouble("latitude"), rs.getDouble("longitude"));
+        PGgeometry geometry = (PGgeometry) rs.getObject("location_geo");
+        Point point = geometry.getGeometry().getFirstPoint();
+        Location location = new Location(point.y, point.x);
         Household household = new Household(rs.getString("address"), location);
         String status = rs.getString("household_status");
         household.setStatus(Status.valueOf(status));

--- a/src/main/resources/V2__migrateToGeo.sql
+++ b/src/main/resources/V2__migrateToGeo.sql
@@ -1,0 +1,19 @@
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+SELECT postgis_extensions_upgrade();
+
+ALTER TABLE household
+ADD location_geo geometry(POINT,4326);
+
+CREATE INDEX household_geom_x ON household USING GIST (location_geo);
+
+ALTER TABLE household
+ADD CONSTRAINT enforce_geotype_geom CHECK (geometrytype(location_geo) = 'POINT'::text);
+
+ALTER TABLE household
+ADD CONSTRAINT enforce_longitude CHECK (ST_X(location_geo) <= 180.0 AND ST_X(location_geo) >= -180.0);
+
+ALTER TABLE household
+ADD CONSTRAINT enforce_latitude CHECK (ST_Y(location_geo) <= 90.0 AND ST_Y(location_geo) >= -90.0);
+
+

--- a/src/test/java/com/example/canvassing/persistence/QuestionnaireRepositoryTest.java
+++ b/src/test/java/com/example/canvassing/persistence/QuestionnaireRepositoryTest.java
@@ -23,6 +23,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,9 +99,12 @@ public class QuestionnaireRepositoryTest {
     return questionnaire;
   }
 
+
   static class TestConfig {
+
+    static DockerImageName myImage = DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-    "postgres:16-alpine"
+    myImage
   );
 
   @Bean

--- a/src/test/java/com/example/canvassing/persistence/ResponseRepositoryTest.java
+++ b/src/test/java/com/example/canvassing/persistence/ResponseRepositoryTest.java
@@ -10,8 +10,6 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -26,9 +24,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ResponseRepositoryTest.TestConfig.class)
@@ -87,8 +85,9 @@ private Questionnaire createQuestionnaire() {
     return questionnaire;
   }
   static class TestConfig {
+    static DockerImageName myImage = DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-    "postgres:16-alpine"
+    myImage
   );
 
   @Bean


### PR DESCRIPTION
1. Create a new Postgis geometry point column in the `household` table.
2. New addresses are inserted including the new column.
3. Nearest households are retrieved using the Postgis column, which uses an index instead of a full table scan.